### PR TITLE
swipe ALL the things!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bower_components/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!---
 
 This README is automatically generated from the comments in these files:
@@ -12,4 +11,3 @@ Edit this file, and the bot will squash your changes :)
 [![Build Status](https://travis-ci.org/PolymerElements/iron-swipeable-container.svg?branch=master)](https://travis-ci.org/PolymerElements/iron-swipeable-container)
 
 _[Demo and API Docs](https://elements.polymer-project.org/elements/iron-swipeable-container)_
-

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,37 @@
+{
+  "name": "iron-swipeable-container",
+  "version": "1.0.0",
+  "description": "A container that alows any of its nested children to be swiped away.",
+  "authors": [
+    "The Polymer Authors"
+  ],
+  "keywords": [
+    "web-components",
+    "polymer",
+    "swipe",
+    "swipeable"
+  ],
+  "main": [
+    "iron-swipeable-container.html"
+  ],
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/PolymerElements/iron-swipeable-container.git"
+  },
+  "license": "http://polymer.github.io/LICENSE.txt",
+  "homepage": "https://github.com/PolymerElements/iron-swipeable-container",
+  "ignore": [],
+  "dependencies": {
+    "polymer": "Polymer/polymer#^1.1.0"
+  },
+  "devDependencies": {
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "web-component-tester": "*",
+    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",
+    "paper-card": "PolymerElements/paper-card#^1.0.0",
+    "paper-styles": "PolymerElements/paper-styles#^1.0.0"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0",

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html lang="en">
+<head>
+  <title>iron-swipeable-container demo</title>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <link rel="import" href="../iron-swipeable-container.html">
+  <link rel="import" href="../../paper-card/paper-card.html">
+  <link rel="import" href="../../paper-styles/demo-pages.html">
+  <link rel="import" href="../../paper-styles/color.html">
+
+  <style is="custom-style">
+    paper-card {
+      width: 100%;
+      margin-bottom: 16px;
+    }
+
+    .item {
+      margin-bottom: 16px;
+      padding: 20px;
+      background-color: var(--paper-lime-500);
+    }
+
+    .item.blue {
+      background-color: var(--paper-blue-300);
+    }
+
+    /* If you want your things to swipe nicely, you might want to disable
+     * text selection on those elements. */
+    .swipe {
+      -moz-user-select: none;
+      -ms-user-select: none;
+      -webkit-user-select: none;
+      user-select: none;
+      cursor: default;
+    }
+  </style>
+
+</head>
+<body unresolved>
+  <div class="vertical-section-container centered">
+    <h4>Curve swipe</h4>
+    <div class="vertical-section">
+      <iron-swipeable-container>
+        <div class="item swipe">You can swipe native elements. This is a plain div.</div>
+
+        <paper-card class="swipe" heading="Swipe me!">
+          <div class="card-content">
+            You can automatically swipe custom elements, too. This is a paper-card.
+          </div>
+        </paper-card>
+
+        <paper-card class="swipe">
+          <div class="card-content">
+            This is another paper-card. Hello!
+          </div>
+        </paper-card>
+
+        <div class="item blue disable-swipe">This is another div but it can't be swiped.</div>
+      </iron-swipeable-container>
+    </div>
+
+    <h4>Horizontal swipe</h4>
+    <div class="vertical-section">
+      <iron-swipeable-container swipe-style="horizontal">
+        <div class="item swipe">You can swipe native elements. This is a plain div.</div>
+
+        <paper-card class="swipe" heading="Swipe me!">
+          <div class="card-content">
+            You can automatically swipe custom elements, too. This is a paper-card.
+          </div>
+        </paper-card>
+
+        <paper-card class="swipe">
+          <div class="card-content">
+            This is another paper-card. Hello!
+          </div>
+        </paper-card>
+
+        <div class="item blue disable-swipe">This is another div but it can't be swiped.</div>
+      </iron-swipeable-container>
+    </div>
+
+    <h4>Swipe disabled</h4>
+    <div class="vertical-section">
+      <iron-swipeable-container disable-swipe>
+        <div class="item swipe">You can swipe native elements. This is a plain div.</div>
+
+        <paper-card class="swipe" heading="Swipe me!">
+          <div class="card-content">
+            You can automatically swipe custom elements, too. This is a paper-card.
+          </div>
+        </paper-card>
+
+        <paper-card class="swipe">
+          <div class="card-content">
+            This is another paper-card. Hello!
+          </div>
+        </paper-card>
+
+        <div class="item blue">This is another div.</div>
+      </iron-swipeable-container>
+    </div>
+  </div>
+</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -52,7 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body unresolved>
   <div class="vertical-section-container centered">
-    <h4>Curve swipe</h4>
+    <h4>Horizontal swipe</h4>
     <div class="vertical-section">
       <iron-swipeable-container>
         <div class="item swipe">You can swipe native elements. This is a plain div.</div>
@@ -73,9 +73,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </iron-swipeable-container>
     </div>
 
-    <h4>Horizontal swipe</h4>
+    <h4>Curve swipe</h4>
     <div class="vertical-section">
-      <iron-swipeable-container swipe-style="horizontal">
+      <iron-swipeable-container swipe-style="curve">
         <div class="item swipe">You can swipe native elements. This is a plain div.</div>
 
         <paper-card class="swipe" heading="Swipe me!">
@@ -96,7 +96,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <h4>Swipe disabled</h4>
     <div class="vertical-section">
-      <iron-swipeable-container disable-swipe>
+      <iron-swipeable-container disabled>
         <div class="item swipe">You can swipe native elements. This is a plain div.</div>
 
         <paper-card class="swipe" heading="Swipe me!">

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>iron-swipeable-container</title>
+
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
+
+</head>
+<body>
+
+<iron-component-page></iron-component-page>
+
+</body>
+</html>

--- a/iron-swipeable-container.html
+++ b/iron-swipeable-container.html
@@ -67,24 +67,24 @@ want to be swiped:
     /**
      * Fired when a child element is swiped away.
      *
-     * @event iron-swipe-away
+     * @event iron-swipe
      */
 
     properties: {
       /**
        * The style in which to swipe the card. Currently supported
        * options are `curve | horizontal`. If left unspecified, the default
-       * is assumed to be `curve`.
+       * is assumed to be `horizontal`.
        */
       swipeStyle: {
        type: String,
-       value: 'curve'
+       value: 'horizontal'
       },
 
       /**
        * If true, then the container will not allow swiping.
        */
-      disableSwipe: {
+      disabled: {
         type: Boolean,
         value: false
       },
@@ -92,7 +92,7 @@ want to be swiped:
       /**
        * The ratio of the width of the element that the translation animation
        * should happen over. For example, if the `widthRatio` is 3, the
-       * animation will take place on a distance 3 times the width of then
+       * animation will take place on a distance 3 times the width of the
        * element being swiped.
        */
       widthRatio: {
@@ -117,19 +117,13 @@ want to be swiped:
       transition: {
         type: String,
         value: '300ms cubic-bezier(0.4, 0.0, 0.2, 1)'
-      },
-
-      /**
-       * The CSS transition property applied while swiping.
-       */
-      transitionProperty: {
-        type: String,
-        value: 'opacity, transform'
       }
     },
 
-    listeners: {
-      'iron-swipe-away': '_swipeAway'
+    ready: function() {
+      this._transitionProperty = 'opacity, transform';
+      this._swipeComplete = false;
+      this._direction = '';
     },
 
     attached: function() {
@@ -148,12 +142,11 @@ want to be swiped:
       if (node.nodeType === Node.TEXT_NODE)
         return;
       // Set up the animation.
-      node.style.transitionProperty = this.transitionProperty;
-      node.style.transition = node.style.webkitTransition = this.transition;
+      node.style.transitionProperty = this._transitionProperty;
+      node.style.transition = this.transition;
 
       this.listen(node, 'track', '_onTrack');
       this.listen(node, 'transitionend', '_onTransitionEnd');
-      this.listen(node, 'webkitTransitionEnd', '_onTransitionEnd');
     },
 
     _removeListeners: function(node) {
@@ -161,17 +154,17 @@ want to be swiped:
         return;
       this.unlisten(node, 'track', '_onTrack');
       this.unlisten(node, 'transitionend', '_onTransitionEnd');
-      this.unlisten(node, 'webkitTransitionEnd', '_onTransitionEnd');
     },
 
     detached: function() {
       if (this._nodeObserver) {
         Polymer.dom(this.$.content).unobserveNodes(this._nodeObserver);
+        this._nodeObserver = null;
       }
     },
 
     _onTrack: function(event) {
-      if (this.disableSwipe)
+      if (this.disabled)
         return;
 
       var target = event.currentTarget;
@@ -192,7 +185,7 @@ want to be swiped:
       // Save the width of the element, so that we don't trigger a style
       // recalc every time we need it.
       this._nodeWidth = target.offsetWidth;
-      target.style.transition = target.style.webkitTransition = 'none';
+      target.style.transition = 'none';
     },
 
     _trackMove: function(event, target) {
@@ -200,8 +193,10 @@ want to be swiped:
     },
 
     _trackEnd: function(event, target) {
-      // The element is swiped away if it's moved halfway its total width
-      this._swipeEnd(Math.abs(event.dx) > this._nodeWidth / 2, event.dx > 0, target);
+      // The element is swiped away if it's moved halfway its total width.
+      this._swipeComplete = Math.abs(event.dx) > this._nodeWidth / 2;
+      this._direction = event.dx > 0;
+      this._swipeEnd(target);
     },
 
     _animate: function(x, target) {
@@ -215,7 +210,7 @@ want to be swiped:
       // transparent, and `x` is how much the element has already travelled.
       var opaqueDistance = Math.max(0, Math.abs(x) - this._nodeWidth * this.opacityRate);
       var opacity = Math.max(0, (totalDistance - opaqueDistance) / totalDistance);
-      target.style.opacity = opacity
+      target.style.opacity = opacity;
 
       var translate, rotate;
 
@@ -233,20 +228,18 @@ want to be swiped:
         rotate = ' rotate(' + deg + 'deg)';
       }
 
-      target.style.transform = target.style.webkitTransform = translate + rotate;
+      this.transform(translate + rotate, target);
     },
 
-    _swipeEnd: function(away, dir, target) {
+    _swipeEnd: function(target) {
       // Restore the original transition;
-      target.style.transition = target.style.webkitTransition = this.transition;
-      this.away = away;
-      this.direction = dir ? 'right' : 'left';
+      target.style.transition = this.transition;
 
-      if (away) {
+      if (this._swipeComplete) {
         // If the element is ready to be swiped away, then translate it to the full
         // transparency distance.
         var totalDistance = this._nodeWidth * this.widthRatio;
-        this._animate(dir ? totalDistance : -totalDistance, target);
+        this._animate(this._direction ? totalDistance : -totalDistance, target);
       } else {
         this._animate(0, target);
       }
@@ -255,14 +248,14 @@ want to be swiped:
     _onTransitionEnd: function(event) {
       var target = event.currentTarget;
 
-      if (this.away && event.propertyName === 'opacity') {
-        this.fire('iron-swipe-away', {direction: this.direction, target:target});
+      if (this._swipeComplete && event.propertyName === 'opacity') {
+        Polymer.dom(this).removeChild(target);
+        this.fire('iron-swipe',
+            { direction: this._direction > 0 ? 'right' : 'left',
+              target:target
+            });
       }
-      event.stopPropagation();
-    },
-
-    _swipeAway: function(event) {
-      Polymer.dom(this).removeChild(event.detail.target);
     }
+
   });
 </script>

--- a/iron-swipeable-container.html
+++ b/iron-swipeable-container.html
@@ -1,0 +1,268 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+
+<!--
+`<iron-swipeable-container>` is a container that allows any of its nested
+children (native or custom elements) to be swiped away. By default it supports
+a curved or horizontal transition, but the transition duration and properties
+can be customized.
+
+Example:
+
+    <iron-swipeable-container>
+      <div>I can be swiped</div>
+      <paper-card heading="Me too!"></paper-card>
+    </iron-swipeable-container>
+
+To disable swiping on individual children, you must give them the `.disable-swipe`
+class. Alternatively, to disable swiping on the whole container, you can use its
+`disable-swipe` attribute:
+
+    <iron-swipeable-container>
+      <div class="disable-swipe">I cannot be swiped be swiped</div>
+      <paper-card heading="But I can!"></paper-card>
+    </iron-swipeable-container>
+
+    <iron-swipeable-container disable-swipe>
+      <div>I cannot be swiped</div>
+      <paper-card heading="Me neither :("></paper-card>
+    </iron-swipeable-container>
+
+It is a good idea to disable text selection on any of the children that you
+want to be swiped:
+
+    .swipe {
+      -moz-user-select: none;
+      -ms-user-select: none;
+      -webkit-user-select: none;
+      user-select: none;
+      cursor: default;
+    }
+
+@group Iron Elements
+@element iron-swipeable-container
+@demo demo/index.html
+-->
+
+<dom-module id="iron-swipeable-container">
+  <template>
+    <content id="content"></content>
+  </template>
+</dom-module>
+
+<script>
+
+  Polymer({
+    is: 'iron-swipeable-container',
+
+    /**
+     * Fired when a child element is swiped away.
+     *
+     * @event iron-swipe-away
+     */
+
+    properties: {
+      /**
+       * The style in which to swipe the card. Currently supported
+       * options are `curve | horizontal`. If left unspecified, the default
+       * is assumed to be `curve`.
+       */
+      swipeStyle: {
+       type: String,
+       value: 'curve'
+      },
+
+      /**
+       * If true, then the container will not allow swiping.
+       */
+      disableSwipe: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
+       * The ratio of the width of the element that the translation animation
+       * should happen over. For example, if the `widthRatio` is 3, the
+       * animation will take place on a distance 3 times the width of then
+       * element being swiped.
+       */
+      widthRatio: {
+       type: Number,
+       value: 3
+      },
+
+      /**
+       * The ratio of the total animation distance after which the opacity
+       * transformation begins. For example, if the `widthRatio` is 1 and
+       * the `opacityRate` is 0.5, then the element needs to travel half its
+       * width before its opacity starts decreasing.
+       */
+      opacityRate: {
+       type: Number,
+       value: 0.2
+      },
+
+      /**
+       * The CSS transition applied while swiping.
+       */
+      transition: {
+        type: String,
+        value: '300ms cubic-bezier(0.4, 0.0, 0.2, 1)'
+      },
+
+      /**
+       * The CSS transition property applied while swiping.
+       */
+      transitionProperty: {
+        type: String,
+        value: 'opacity, transform'
+      }
+    },
+
+    listeners: {
+      'iron-swipe-away': '_swipeAway'
+    },
+
+    attached: function() {
+      this._nodeObserver = Polymer.dom(this.$.content).observeNodes(
+          function(mutations) {
+            for (var i = 0; i < mutations.addedNodes.length; i++) {
+              this._addListeners(mutations.addedNodes[i]);
+            }
+            for (var i = 0; i < mutations.removedNodes.length; i++) {
+              this._removeListeners(mutations.removedNodes[i]);
+            }
+          }.bind(this));
+    },
+
+    _addListeners: function(node) {
+      if (node.nodeType === Node.TEXT_NODE)
+        return;
+      // Set up the animation.
+      node.style.transitionProperty = this.transitionProperty;
+      node.style.transition = node.style.webkitTransition = this.transition;
+
+      this.listen(node, 'track', '_onTrack');
+      this.listen(node, 'transitionend', '_onTransitionEnd');
+      this.listen(node, 'webkitTransitionEnd', '_onTransitionEnd');
+    },
+
+    _removeListeners: function(node) {
+      if (node.nodeType === Node.TEXT_NODE)
+        return;
+      this.unlisten(node, 'track', '_onTrack');
+      this.unlisten(node, 'transitionend', '_onTransitionEnd');
+      this.unlisten(node, 'webkitTransitionEnd', '_onTransitionEnd');
+    },
+
+    detached: function() {
+      if (this._nodeObserver) {
+        Polymer.dom(this.$.content).unobserveNodes(this._nodeObserver);
+      }
+    },
+
+    _onTrack: function(event) {
+      if (this.disableSwipe)
+        return;
+
+      var target = event.currentTarget;
+      if (target.classList.contains('disable-swipe'))
+        return;
+
+      var track = event.detail;
+      if (track.state === 'start') {
+        this._trackStart(track, target);
+      } else if (track.state === 'track') {
+        this._trackMove(track, target);
+      } else if (track.state === 'end') {
+        this._trackEnd(track, target);
+      }
+    },
+
+    _trackStart: function(event, target) {
+      // Save the width of the element, so that we don't trigger a style
+      // recalc every time we need it.
+      this._nodeWidth = target.offsetWidth;
+      target.style.transition = target.style.webkitTransition = 'none';
+    },
+
+    _trackMove: function(event, target) {
+      this._animate(event.dx, target);
+    },
+
+    _trackEnd: function(event, target) {
+      // The element is swiped away if it's moved halfway its total width
+      this._swipeEnd(Math.abs(event.dx) > this._nodeWidth / 2, event.dx > 0, target);
+    },
+
+    _animate: function(x, target) {
+      var direction = x > 0 ? 1 : -1;
+
+      // This is the total distance the animation will take place over.
+      var totalDistance = this._nodeWidth * this.widthRatio;
+
+      // Opacity distance overflow. `this._nodeWidth * this.opacityRate` is the
+      // total distance the element needs to travel to become completely
+      // transparent, and `x` is how much the element has already travelled.
+      var opaqueDistance = Math.max(0, Math.abs(x) - this._nodeWidth * this.opacityRate);
+      var opacity = Math.max(0, (totalDistance - opaqueDistance) / totalDistance);
+      target.style.opacity = opacity
+
+      var translate, rotate;
+
+      if (this.swipeStyle === 'horizontal') {
+        translate = 'translate3d(' + x + 'px,' + 0 + 'px,0)';
+        rotate = '';
+      } else {  // Default is assumed to be `curve`.
+        // Assume the element will be completely transparent at 90 degrees, so
+        // figure out the rotation and vertical displacement needed to
+        // achieve that.
+        var y = totalDistance - Math.sqrt(totalDistance * totalDistance - opaqueDistance * opaqueDistance);
+        var deg = (1 - opacity) * direction * 90;
+
+        translate = 'translate3d(' + x + 'px,' + y + 'px,0)';
+        rotate = ' rotate(' + deg + 'deg)';
+      }
+
+      target.style.transform = target.style.webkitTransform = translate + rotate;
+    },
+
+    _swipeEnd: function(away, dir, target) {
+      // Restore the original transition;
+      target.style.transition = target.style.webkitTransition = this.transition;
+      this.away = away;
+      this.direction = dir ? 'right' : 'left';
+
+      if (away) {
+        // If the element is ready to be swiped away, then translate it to the full
+        // transparency distance.
+        var totalDistance = this._nodeWidth * this.widthRatio;
+        this._animate(dir ? totalDistance : -totalDistance, target);
+      } else {
+        this._animate(0, target);
+      }
+    },
+
+    _onTransitionEnd: function(event) {
+      var target = event.currentTarget;
+
+      if (this.away && event.propertyName === 'opacity') {
+        this.fire('iron-swipe-away', {direction: this.direction, target:target});
+      }
+      event.stopPropagation();
+    },
+
+    _swipeAway: function(event) {
+      Polymer.dom(this).removeChild(event.detail.target);
+    }
+  });
+</script>

--- a/test/basic.html
+++ b/test/basic.html
@@ -16,20 +16,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-swipeable-container.html">
   <link rel="import" href="test-element.html">
 
 </head>
 <style>
-div {
-  width: 100px;
-  height: 100px;
-  background-color: blue;
-}
+  div {
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+  }
 </style>
 <body>
 
@@ -52,9 +50,9 @@ div {
   </test-fixture>
 
 
-  <test-fixture id="no-swipe" disable-swipe>
+  <test-fixture id="no-swipe">
     <template>
-      <iron-swipeable-container>
+      <iron-swipeable-container disabled>
         <div id="native">Hello</div>
         <test-element id="custom"></test-element>
       </iron-swipeable-container>
@@ -70,16 +68,16 @@ div {
 
         Polymer.Base.async(function() {
           var swipeEventHandler = sinon.spy();
-          container.addEventListener('iron-swipe-away', swipeEventHandler);
+          container.addEventListener('iron-swipe', swipeEventHandler);
 
           expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
           MockInteractions.track(element, 10, 0);
 
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(swipeEventHandler.callCount).to.be.equal(0);
             expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
             done();
-          }, 100);
+          }, 1);
         });
       });
 
@@ -90,7 +88,7 @@ div {
         Polymer.Base.async(function() {
           expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
 
-          container.addEventListener('iron-swipe-away', function(event) {
+          container.addEventListener('iron-swipe', function(event) {
             expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(1);
             done();
           });
@@ -105,16 +103,16 @@ div {
 
         Polymer.Base.async(function() {
           var swipeEventHandler = sinon.spy();
-          container.addEventListener('iron-swipe-away', swipeEventHandler);
+          container.addEventListener('iron-swipe', swipeEventHandler);
 
           expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
           MockInteractions.track(element, 60, 0);  // this amount would normally swipe.
 
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(swipeEventHandler.callCount).to.be.equal(0);
             expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
             done();
-          }, 100);
+          }, 1);
         });
       });
     });
@@ -125,17 +123,17 @@ div {
         var element = container.querySelector('#custom');
 
         var swipeEventHandler = sinon.spy();
-        container.addEventListener('iron-swipe-away', swipeEventHandler);
+        container.addEventListener('iron-swipe', swipeEventHandler);
 
         Polymer.Base.async(function() {
           expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
           MockInteractions.track(element, 10, 0);
 
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(swipeEventHandler.callCount).to.be.equal(0);
             expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
             done();
-          }, 100);
+          }, 1);
         });
       });
 
@@ -146,7 +144,7 @@ div {
         Polymer.Base.async(function() {
           expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
 
-          container.addEventListener('iron-swipe-away', function(event) {
+          container.addEventListener('iron-swipe', function(event) {
             expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(1);
             done();
           });
@@ -161,16 +159,16 @@ div {
 
         Polymer.Base.async(function() {
           var swipeEventHandler = sinon.spy();
-          container.addEventListener('iron-swipe-away', swipeEventHandler);
+          container.addEventListener('iron-swipe', swipeEventHandler);
 
           expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
           MockInteractions.track(element, 60, 0);  // this amount would normally swipe.
 
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(swipeEventHandler.callCount).to.be.equal(0);
             expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
             done();
-          }, 100);
+          }, 1);
         });
       });
     });
@@ -181,17 +179,17 @@ div {
         var element = container.querySelector('#native');
 
         var swipeEventHandler = sinon.spy();
-        container.addEventListener('iron-swipe-away', swipeEventHandler);
+        container.addEventListener('iron-swipe', swipeEventHandler);
 
         Polymer.Base.async(function() {
           expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
           MockInteractions.track(element, 60, 0);
 
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(swipeEventHandler.callCount).to.be.equal(0);
             expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
             done();
-          }, 100);
+          }, 1);
         });
       });
 
@@ -200,17 +198,17 @@ div {
         var element = container.querySelector('#custom');
 
         var swipeEventHandler = sinon.spy();
-        container.addEventListener('iron-swipe-away', swipeEventHandler);
+        container.addEventListener('iron-swipe', swipeEventHandler);
 
         Polymer.Base.async(function() {
           expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
           MockInteractions.track(element, 60, 0);
 
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(swipeEventHandler.callCount).to.be.equal(0);
             expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
             done();
-          }, 100);
+          }, 1);
         });
       });
     });

--- a/test/basic.html
+++ b/test/basic.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>iron-swipeable-container tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
+
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../iron-swipeable-container.html">
+  <link rel="import" href="test-element.html">
+
+</head>
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background-color: blue;
+}
+</style>
+<body>
+
+  <test-fixture id="basic">
+    <template>
+      <iron-swipeable-container>
+        <div id="native">Hello</div>
+        <test-element id="custom"></test-element>
+      </iron-swipeable-container>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="child-no-swipe">
+    <template>
+      <iron-swipeable-container>
+        <div id="native" class="disable-swipe">Hello</div>
+        <test-element id="custom" class="disable-swipe"></test-element>
+      </iron-swipeable-container>
+    </template>
+  </test-fixture>
+
+
+  <test-fixture id="no-swipe" disable-swipe>
+    <template>
+      <iron-swipeable-container>
+        <div id="native">Hello</div>
+        <test-element id="custom"></test-element>
+      </iron-swipeable-container>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    suite('native elements', function() {
+      test('dragging less than halfway does not swipe', function(done) {
+        var container = fixture('basic');
+        var element = container.querySelector('#native');
+
+        Polymer.Base.async(function() {
+          var swipeEventHandler = sinon.spy();
+          container.addEventListener('iron-swipe-away', swipeEventHandler);
+
+          expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+          MockInteractions.track(element, 10, 0);
+
+          setTimeout(function(){
+            expect(swipeEventHandler.callCount).to.be.equal(0);
+            expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+            done();
+          }, 100);
+        });
+      });
+
+      test('dragging more than halfway swipes it', function(done) {
+        var container = fixture('basic');
+        var element = container.querySelector('#native');
+
+        Polymer.Base.async(function() {
+          expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+
+          container.addEventListener('iron-swipe-away', function(event) {
+            expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(1);
+            done();
+          });
+
+          MockInteractions.track(element, 60, 0);
+        });
+      });
+
+      test('an element with disable-swipe cannot be swiped', function(done) {
+        var container = fixture('child-no-swipe');
+        var element = container.querySelector('#native');
+
+        Polymer.Base.async(function() {
+          var swipeEventHandler = sinon.spy();
+          container.addEventListener('iron-swipe-away', swipeEventHandler);
+
+          expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+          MockInteractions.track(element, 60, 0);  // this amount would normally swipe.
+
+          setTimeout(function(){
+            expect(swipeEventHandler.callCount).to.be.equal(0);
+            expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+            done();
+          }, 100);
+        });
+      });
+    });
+
+    suite('custom elements', function() {
+      test('dragging less than halfway does not swipe', function(done) {
+        var container = fixture('basic');
+        var element = container.querySelector('#custom');
+
+        var swipeEventHandler = sinon.spy();
+        container.addEventListener('iron-swipe-away', swipeEventHandler);
+
+        Polymer.Base.async(function() {
+          expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+          MockInteractions.track(element, 10, 0);
+
+          setTimeout(function(){
+            expect(swipeEventHandler.callCount).to.be.equal(0);
+            expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+            done();
+          }, 100);
+        });
+      });
+
+      test('dragging more than halfway swipes it', function(done) {
+        var container = fixture('basic');
+        var element = container.querySelector('#custom');
+
+        Polymer.Base.async(function() {
+          expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+
+          container.addEventListener('iron-swipe-away', function(event) {
+            expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(1);
+            done();
+          });
+
+          MockInteractions.track(element, 60, 0);
+        });
+      });
+
+      test('an element with disable-swipe cannot be swiped', function(done) {
+        var container = fixture('child-no-swipe');
+        var element = container.querySelector('#custom');
+
+        Polymer.Base.async(function() {
+          var swipeEventHandler = sinon.spy();
+          container.addEventListener('iron-swipe-away', swipeEventHandler);
+
+          expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+          MockInteractions.track(element, 60, 0);  // this amount would normally swipe.
+
+          setTimeout(function(){
+            expect(swipeEventHandler.callCount).to.be.equal(0);
+            expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+            done();
+          }, 100);
+        });
+      });
+    });
+
+    suite('no swipe', function() {
+      test('dragging a native element more than halfway does not swipe', function(done) {
+        var container = fixture('no-swipe');
+        var element = container.querySelector('#native');
+
+        var swipeEventHandler = sinon.spy();
+        container.addEventListener('iron-swipe-away', swipeEventHandler);
+
+        Polymer.Base.async(function() {
+          expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+          MockInteractions.track(element, 60, 0);
+
+          setTimeout(function(){
+            expect(swipeEventHandler.callCount).to.be.equal(0);
+            expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+            done();
+          }, 100);
+        });
+      });
+
+      test('dragging a custom element more than halfway does not swipe', function(done) {
+        var container = fixture('no-swipe');
+        var element = container.querySelector('#custom');
+
+        var swipeEventHandler = sinon.spy();
+        container.addEventListener('iron-swipe-away', swipeEventHandler);
+
+        Polymer.Base.async(function() {
+          expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+          MockInteractions.track(element, 60, 0);
+
+          setTimeout(function(){
+            expect(swipeEventHandler.callCount).to.be.equal(0);
+            expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
+            done();
+          }, 100);
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>iron-swipeable-container tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+</head>
+<body>
+  <script>
+    WCT.loadSuites([
+      'basic.html'
+    ]);
+  </script>
+</body>
+</html>

--- a/test/test-element.html
+++ b/test/test-element.html
@@ -1,0 +1,35 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+
+<dom-module id="test-element">
+  <style>
+    :host {
+      display: inline-block;
+    }
+
+    .item {
+      width: 100px;
+      height: 20px;
+      background-color: red;
+    }
+
+  </style>
+  <template>
+    <div class="item"></div>
+  </template>
+
+  <script>
+    Polymer({
+      is: 'test-element'
+    });
+  </script>
+</dom-module>


### PR DESCRIPTION
I ported the old `PolymerLabs/swipeable-card` to a magical container that makes all its children swipeable. I tried to comment all the magical animation stuff that was really scary -- @frankiefu, would you mind double checking that I didn't tell any lies in `_animate`?

Features:
- curved and horizontal swiping
- the css transform can be configured, as well as the animation/opacity duration
- all children can be swiped
- swiping can be prevented on the whole container
- swiping can be prevented on individual children