### PR TITLE
Prevent swipes from bubbling to parent elements

### DIFF
--- a/iron-swipeable-container.html
+++ b/iron-swipeable-container.html
@@ -184,6 +184,7 @@ want to be swiped:
       } else if (track.state === 'end') {
         this._trackEnd(track, target);
       }
+      event.stopPropagation();
     },
 
     _trackStart: function(event, target) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -59,6 +59,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+
+  <test-fixture id="nested-swipe">
+    <template>
+      <iron-swipeable-container id="outer">
+        <iron-swipeable-container id="inner">
+          <div id="native"></div>
+        </iron-swipeable-container>
+      </iron-swipeable-container>
+    </template>
+  </test-fixture>
+
   <script>
 
     suite('native elements', function() {
@@ -209,6 +220,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(Polymer.dom(container).queryDistributedElements('*').length).to.be.equal(2);
             done();
           }, 1);
+        });
+      });
+    });
+
+    suite('nested swipe', function() {
+      test('dragging an element nested in two containers does not swipe both', function(done) {
+        var outer = fixture('nested-swipe');
+        var inner = outer.querySelector('#inner');
+        var element = inner.querySelector('#native');
+        var innerTransforms = [];
+
+        var swipeEventHandler = sinon.spy();
+        outer.addEventListener('iron-swipe', swipeEventHandler);
+
+        Polymer.Base.async(function() {
+          element.addEventListener('mousemove', function(event) {
+            innerTransforms.push(inner.style.transform);
+          });
+
+          inner.addEventListener('iron-swipe', function(event) {
+            expect(innerTransforms.join('')).to.be.equal('');
+            done();
+          });
+
+          MockInteractions.track(element, 60, 0);
         });
       });
     });


### PR DESCRIPTION
Currently if a swipeable container is contained in some other swipeable element, swiping an inner-nested element causes both containers to swipe.  By stopping propagation after a successful track event, this undesired behavior is prevented.