### PR TITLE
Fix test timeouts; work around an IE11 specific bug.

### DIFF
--- a/iron-swipeable-container.html
+++ b/iron-swipeable-container.html
@@ -85,7 +85,7 @@ want to be swiped:
       /**
        * If true, then the container will not allow swiping.
        */
-      disabled: {type: Boolean, value: false},
+      disabled: {type: Boolean, value: false, observer: '_NOOP_IE11'},
 
       /**
        * The ratio of the width of the element that the translation animation
@@ -108,6 +108,10 @@ want to be swiped:
        */
       transition: {type: String, value: '300ms cubic-bezier(0.4, 0.0, 1, 1)'}
     },
+
+    // This observer is only here because it prevents a bug that occurs in IE11
+    // where attributes used to set boolean properties do not otherwise apply.
+    _NOOP_IE11: function() {},
 
     ready: function() {
       this._transitionProperty = 'opacity, transform';

--- a/iron-swipeable-container.html
+++ b/iron-swipeable-container.html
@@ -85,7 +85,7 @@ want to be swiped:
       /**
        * If true, then the container will not allow swiping.
        */
-      disabled: {type: Boolean, value: false, observer: '_NOOP_IE11'},
+      disabled: {type: Boolean, value: false, observer: '__NOOP_IE11'},
 
       /**
        * The ratio of the width of the element that the translation animation
@@ -111,7 +111,7 @@ want to be swiped:
 
     // This observer is only here because it prevents a bug that occurs in IE11
     // where attributes used to set boolean properties do not otherwise apply.
-    _NOOP_IE11: function() {},
+    __NOOP_IE11: function() {},
 
     ready: function() {
       this._transitionProperty = 'opacity, transform';

--- a/test/basic.html
+++ b/test/basic.html
@@ -71,6 +71,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </test-fixture>
 
   <script>
+    (function() {
+    // The maximum number of milliseconds after completing a track action that
+    // may occur before the 'iron-swipe' event is dispatched, if any would be.
+    // This value should be longer than the swipe transition.
+    const SWIPE_TIMEOUT = 500;
+
     suite('native elements', function() {
       test('dragging less than halfway does not swipe', function(done) {
         var container = fixture('basic');
@@ -89,8 +95,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(Polymer.dom(container).queryDistributedElements('*').length)
                 .to.be.equal(2);
             done();
-          }, 1);
-        });
+          }, SWIPE_TIMEOUT);
+        }, 1);
       });
 
       test('dragging more than halfway swipes it', function(done) {
@@ -108,7 +114,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
 
           MockInteractions.track(element, 60, 0);
-        });
+        }, 1);
       });
 
       test('an element with disable-swipe cannot be swiped', function(done) {
@@ -129,8 +135,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(Polymer.dom(container).queryDistributedElements('*').length)
                 .to.be.equal(2);
             done();
-          }, 1);
-        });
+          }, SWIPE_TIMEOUT);
+        }, 1);
       });
     });
 
@@ -152,8 +158,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(Polymer.dom(container).queryDistributedElements('*').length)
                 .to.be.equal(2);
             done();
-          }, 1);
-        });
+          }, SWIPE_TIMEOUT);
+        }, 1);
       });
 
       test('dragging more than halfway swipes it', function(done) {
@@ -171,7 +177,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
 
           MockInteractions.track(element, 60, 0);
-        });
+        }, 1);
       });
 
       test('an element with disable-swipe cannot be swiped', function(done) {
@@ -192,8 +198,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             expect(Polymer.dom(container).queryDistributedElements('*').length)
                 .to.be.equal(2);
             done();
-          }, 1);
-        });
+          }, SWIPE_TIMEOUT);
+        }, 1);
       });
     });
 
@@ -217,8 +223,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 expect(Polymer.dom(container).queryDistributedElements('*').length)
                     .to.be.equal(2);
                 done();
-              }, 1);
-            });
+              }, SWIPE_TIMEOUT);
+            }, 1);
           });
 
       test(
@@ -240,8 +246,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                 expect(Polymer.dom(container).queryDistributedElements('*').length)
                     .to.be.equal(2);
                 done();
-              }, 1);
-            });
+              }, SWIPE_TIMEOUT);
+            }, 1);
           });
     });
 
@@ -268,9 +274,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               });
 
               MockInteractions.track(element, 60, 0);
-            });
+            }, 1);
           });
     });
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
Some of the timeouts in the tests weren't waiting until the event listeners were attached before trying to test actions relying on those listeners. Other timeouts weren't waiting long enough before assuming that an 'iron-swipe' that shouldn't be dispatched wasn't. Also, there seems to be a bug in Polymer 2 (not sure if it's specific to the legacy API) where attributes that are meant to set boolean properties don't actually do so in IE11 - adding an observer on this property seems to fix it. :/